### PR TITLE
Adding webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ classes/
 
 # Mac Files
 .DS_Store
+
+family2family/node_modules/
+family2family/src/main/resources/static/build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-defaultTasks 'clean', 'build'
+defaultTasks 'clean', 'bundleJs', 'build'
 
 subprojects {
 

--- a/family2family/.babelrc
+++ b/family2family/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets" : ["es2015", "react"]
+}

--- a/family2family/build.gradle
+++ b/family2family/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath("com.moowork.gradle:gradle-node-plugin:0.12")
     }
 }
 
@@ -16,6 +17,7 @@ version = '1.0.0-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
+apply plugin: "com.moowork.node"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -49,3 +51,17 @@ springBoot {
     // Provides build metadata in the META-INF directory
     buildInfo()
 }
+
+task webpack(type: NodeTask, dependsOn: 'npmInstall') {
+    def osName = System.getProperty("os.name").toLowerCase();
+    if (osName.contains("windows")) {
+        script = project.file('node_modules/webpack/bin/webpack.js')
+    } else {
+        script = project.file('node_modules/.bin/webpack')
+    }
+}
+
+processResources.dependsOn 'webpack'
+
+clean.delete << file('node_modules')
+clean.delete << file('src/main/webapp/dist')

--- a/family2family/build.gradle
+++ b/family2family/build.gradle
@@ -7,8 +7,11 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath("com.moowork.gradle:gradle-node-plugin:0.12")
     }
+}
+
+plugins {
+    id "com.moowork.node" version "1.1.1"
 }
 
 // Update appropriately for releases
@@ -17,7 +20,6 @@ version = '1.0.0-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
-apply plugin: "com.moowork.node"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -52,16 +54,7 @@ springBoot {
     buildInfo()
 }
 
-task webpack(type: NodeTask, dependsOn: 'npmInstall') {
-    def osName = System.getProperty("os.name").toLowerCase();
-    if (osName.contains("windows")) {
-        script = project.file('node_modules/webpack/bin/webpack.js')
-    } else {
-        script = project.file('node_modules/.bin/webpack')
-    }
+task bundleJs(type: NpmTask, dependsOn: 'npmInstall') {
+    // install the express package only
+    args = ['run', 'build']
 }
-
-processResources.dependsOn 'webpack'
-
-clean.delete << file('node_modules')
-clean.delete << file('src/main/webapp/dist')

--- a/family2family/client/test.jsx
+++ b/family2family/client/test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {render} from 'react-dom';
+
+class App extends React.Component {
+    render () {
+        return <p> Hello React234!</p>;
+    }
+}
+
+render(<App/>, document.getElementById('app'));

--- a/family2family/package.json
+++ b/family2family/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "family2family",
+  "version": "1.0.0-SNAPSHOT",
+  "description": "",
+  "scripts": {
+    "dev": "webpack -d --watch",
+    "build": "webpack -p"
+  },
+  "dependencies": {
+    "babel-core": "^6.24.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-react": "^6.23.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "webpack": "^2.3.3"
+  }
+}

--- a/family2family/src/main/java/org/cbtf/f2f/client/TestController.java
+++ b/family2family/src/main/java/org/cbtf/f2f/client/TestController.java
@@ -1,0 +1,19 @@
+package org.cbtf.f2f.client;
+
+import org.cbtf.f2f.util.LoggedInUtil;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class TestController {
+
+    @RequestMapping("/test")
+    public String getAdminPage() {
+        if (LoggedInUtil.isUserLoggedIn()) {
+            return "test";
+        } else {
+            //this page should be protected by the security filter, but just in case it gets opened up..
+            throw new RuntimeException("Unauthorized access to the admin page.");
+        }
+    }
+}

--- a/family2family/src/main/resources/templates/test.html
+++ b/family2family/src/main/resources/templates/test.html
@@ -10,7 +10,7 @@
 <div id="app">
 </div>
 
-<script type="text/javascript" src="../static/build/bundle.js" th:src="@{/build/bundle.js}"></script>
+<script type="text/javascript" src="../static/build/test/test-bundle.js" th:src="@{/build/test/test-bundle.js}"></script>
 
 </body>
 

--- a/family2family/src/main/resources/templates/test.html
+++ b/family2family/src/main/resources/templates/test.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title>F2F</title>
+</head>
+
+<body>
+
+<div id="app">
+</div>
+
+<script type="text/javascript" src="../static/build/bundle.js" th:src="@{/build/bundle.js}"></script>
+
+</body>
+
+</html>

--- a/family2family/src/main/web/test/mycomponent.jsx
+++ b/family2family/src/main/web/test/mycomponent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default class MyComponent extends React.Component {
+    render () {
+        return <p>This is my test component</p>;
+    }
+}

--- a/family2family/src/main/web/test/test.jsx
+++ b/family2family/src/main/web/test/test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {render} from 'react-dom';
+import MyComponent from './mycomponent.jsx';
 
 class App extends React.Component {
     render () {
         return <div>
             <p> Hello React!</p>
+            <MyComponent/>
         </div>;
     }
 }

--- a/family2family/src/main/web/test/test.jsx
+++ b/family2family/src/main/web/test/test.jsx
@@ -3,7 +3,9 @@ import {render} from 'react-dom';
 
 class App extends React.Component {
     render () {
-        return <p> Hello React234!</p>;
+        return <div>
+            <p> Hello React!</p>
+        </div>;
     }
 }
 

--- a/family2family/src/main/web/test/test.jsx
+++ b/family2family/src/main/web/test/test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import ReactDom from 'react-dom';
 import MyComponent from './mycomponent.jsx';
 
 class App extends React.Component {
@@ -11,4 +11,4 @@ class App extends React.Component {
     }
 }
 
-render(<App/>, document.getElementById('app'));
+ReactDom.render(<App/>, document.getElementById('app'));

--- a/family2family/webpack.config.js
+++ b/family2family/webpack.config.js
@@ -1,0 +1,26 @@
+var webpack = require('webpack');
+var path = require('path');
+
+var dir = "./";
+
+var BUILD_DIR = path.resolve(dir, 'src/main/resources/static/build');
+var APP_DIR = path.resolve(dir, 'client');
+
+var config = {
+    entry: APP_DIR + '/test.jsx',
+    output: {
+        path: BUILD_DIR,
+        filename: 'bundle.js'
+    },
+    module: {
+        loaders : [
+            {
+                test : /\.jsx?/,
+                include : APP_DIR,
+                loader: 'babel-loader'
+            }
+        ]
+    }
+};
+
+module.exports = config;

--- a/family2family/webpack.config.js
+++ b/family2family/webpack.config.js
@@ -3,24 +3,60 @@ var path = require('path');
 
 var dir = "./";
 
-var BUILD_DIR = path.resolve(dir, 'src/main/resources/static/build');
-var APP_DIR = path.resolve(dir, 'client');
+var ROOT_BUILD_DIR = path.resolve(dir, 'src/main/resources/static/build');
+var ROOT_APP_DIR = path.resolve(dir, 'src/main/web');
 
-var config = {
-    entry: APP_DIR + '/test.jsx',
-    output: {
-        path: BUILD_DIR,
-        filename: 'bundle.js'
-    },
-    module: {
-        loaders : [
-            {
-                test : /\.jsx?/,
-                include : APP_DIR,
-                loader: 'babel-loader'
-            }
-        ]
+/**
+ * A helper function for generating a new bundled js file based on a configuration name.
+ *
+ * This expects a react file to exist at the location:
+ * <pre>
+ * ./src/main/web/[CONFIG]/[CONFIG].jsx
+ * </pre>
+ *
+ * The webpack command will package up the jsx file in a single js file at:
+ * <pre>
+ * ./src/main/static/build/[CONFIG]/[CONFIG]-bundle.js
+ * </pre>
+ *
+ * When using the resulting file in an html file, import it as:
+ * <pre>
+ * <script type="text/javascript" src="../static/build/[CONFIG]/[CONFIG]-bundle.js" th:src="@{/build/[CONFIG]/[CONFIG]-bundle.js}"></script>
+ * </pre>
+ *
+ * Adding the static src attribute will allow us to view the html file directly, without the server running.
+ *
+ * @param configName the name of the configuration given to the module. This should probably match the html page as well
+ * for consistency purposes.
+ * @returns a module for exporting
+ */
+function getConfig(configName) {
+    var configSourceDir = ROOT_APP_DIR + '/' + configName + '/';
+    var configBuildDir = ROOT_BUILD_DIR + '/' + configName + '/';
+    return {
+        entry: [configSourceDir +  configName + '.jsx'],
+        output: {
+            path: configBuildDir,
+            filename: configName + '-bundle.js'
+        },
+        module: {
+            loaders : [
+                {
+                    test : /\.jsx/,
+                    include : configSourceDir,
+                    loader: 'babel-loader'
+                }
+            ]
+        }
     }
-};
+}
 
-module.exports = config;
+//To add additional configs, just add them to the list here. The naming convention will have to line up.
+var configurations = ['test'];
+
+var exports = [];
+for (var i = 0; i < configurations.length; i++) {
+    exports.push(getConfig(configurations[i]));
+}
+
+module.exports = exports;


### PR DESCRIPTION
Added npm config, babel config, and webpack config to the project to produce [config]-bundle.js files from our *.jsx files that can be referenced from html page(s).

This by itself will give us the ability to:
* import other libraries with standard (ES6?) importing
* import other internal jsx files with standard importing
* give us a path for splitting out client vs server depedencies

Cons:
Since we will now be generating bundle js files via an npm command (webpack underneath) we will not be able to simple rebuild the application for client changes. We will also have to have to run the npm process for creating the bundle.js file.

Current paths for running the application locally after these changes:
1. Using the gradle build
```
Run the gradle build
Start the spring boot run configuration
Change files
Run the gradle build
Rebuild the application
```

2. Run npm commands manually
```
Navigate to the family2family directory
run: `npm dev`
Run the spring boot run configuration
Change files
Rebuild the application
```

We did attempt to create an intellij run configuration for the npm dev command. It seems like it loses connection through intellij quickly and has to be restarted often, running from the command line seems to be much more reliable.